### PR TITLE
Fix for "Waiting for background process(es) to close" screen during reboot/shutdown

### DIFF
--- a/Application/Program.cs
+++ b/Application/Program.cs
@@ -71,6 +71,8 @@ namespace GmailNotifierPlus {
 			String guid = "{421a0043-b2ab-4b86-8dec-63ce3b8bd764}";
 			String name = String.Concat(@"Local\GmailNotifierPlus", guid);
 
+            SystemEvents.SessionEnded += new SessionEndedEventHandler(SystemEvents_SessionEnded);
+
 			using (new Mutex(true, name, out createdNew)) {
 				if (!createdNew) {
 					if (args.Length > 0) {
@@ -103,6 +105,12 @@ namespace GmailNotifierPlus {
 				}
 			}
 		}
+
+        static void SystemEvents_SessionEnded(object sender, SessionEndedEventArgs e)
+        {
+            Application.Exit();
+            SystemEvents.SessionEnded -= SystemEvents_SessionEnded;
+        }
 
 		public class RemotingService : MarshalByRefObject {
 			public void CheckMail() {


### PR DESCRIPTION
Added event handler for SystemEvents.SessionEnded so that the application quits when the user ends the current session. This fixes the issue of Windows bringing up the "Waiting for background process(es) to close" screen during reboot/shutdown
